### PR TITLE
Add dom extension as composer dependency + add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
         "psr-0": {
             "CFPropertyList\\": "classes/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "homepage": "https://github.com/rodneyrehm/CFPropertyList",
     "license": "MIT",
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "ext-dom": "*"
     },
     "authors": [
         {
@@ -24,7 +25,7 @@
     },
     "autoload": {
         "psr-0": {
-            "CFPropertyList":"classes\/"
+            "CFPropertyList\\": "classes/"
         }
     }
 }


### PR DESCRIPTION
DOM is required for reading (XML) plists, so I thought it should be listed in the composer dependencies.

Also, I've corrected/adjusted the PSR-0 autoload definition to match the namespace autoloading example in the Composer documentation (http://getcomposer.org/doc/01-basic-usage.md#autoloading); escaping the forward slash isn't necessary.